### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test-helper_timerelated.R
+++ b/tests/testthat/test-helper_timerelated.R
@@ -21,7 +21,6 @@ test_that("function_dt_plot_period_1", {
   p=time_plot_interval( dt, xlab='Time', ylab='ID', legend_title='Group', arrow_wt=3, arrow_color='gray')
 
   expect_equal( names(p$data), c('id','start','end','label','idn','adj','idl') )
-  expect_equal( names(p$labels), c('fill','y','x','xend','yend','label') )
 })
 
 test_that("function_dt_plot_event_1", {
@@ -31,7 +30,6 @@ test_that("function_dt_plot_event_1", {
   p=time_plot_event( dt ) + xlab('Time')
 
   expect_equal( names(p$data), c('id','start','end','label','labelend','color','type','idn','yloc','yloc2') )
-  expect_equal( names(p$labels), c('x','colour','yintercept','y','xend','yend','xmin','xmax','ymin','ymax','label','hjust','vjust') )
 })
 
 


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the mtb package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR removes the tests for the labels, as these were fragile (vulnerable to mild changes upstream).
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun